### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ API reference
 
 A up-to-date API reference generated using Doxygen is available in the */doc* folder.
 
-You can view the API reference online [here](https://rawgit.com/bnoffer/owncloud-sharp/master/doc/html/index.html) .
+You can view the API reference online [here](https://combinatronics.com/bnoffer/owncloud-sharp/master/doc/html/index.html) .
 
 Sample Code
 ===========


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.